### PR TITLE
Update footer to display current year dynamically

### DIFF
--- a/grupo11/templates/partials/footer.html
+++ b/grupo11/templates/partials/footer.html
@@ -1,5 +1,6 @@
 <footer class="rodape">
-    <p class="rodape-texto">© 2025 Projeto Integrador UNIVESP | Sistema de cadastro e gerenciamento de castrações</p>
+    <p class="rodape-texto">© {% now "Y" %} Projeto Integrador UNIVESP | Sistema de cadastro e gerenciamento de
+        castrações</p>
     <a href="https://github.com/vitox761/PJI110-GRUPO11" class="rodape-link" target="_blank" rel="noopener noreferrer">
         <i class="fab fa-github"></i> GitHub
     </a>


### PR DESCRIPTION
This pull request includes a small change to the `grupo11/templates/partials/footer.html` file. The change updates the footer text to dynamically display the current year using a template tag.

* [`grupo11/templates/partials/footer.html`](diffhunk://#diff-6a8e1df9cc7cc1cddf4de585d9e60e8db6c019e3fcc2f9ca9c0fa870fd372b1aL2-R3): Updated the footer text to dynamically display the current year using the `{% now "Y" %}` template tag.