### PR TITLE
Add footer styles to multiple CSS files for consistent design

### DIFF
--- a/grupo11/static/css/deletar_style.css
+++ b/grupo11/static/css/deletar_style.css
@@ -112,6 +112,28 @@ body {
     height: auto;
 }
 
+.rodape {
+    background-color: #4D77A8;
+    color: white;
+    text-align: center;
+    padding: 20px;
+    margin-top: 48px;
+}
+
+.rodape-texto {
+    margin: 10px 0;
+}
+
+.rodape-link {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.rodape-link:hover {
+    color: #c0d8e8;
+}
+
 @media only screen and (max-width: 600px) {
 
     .cabecalho-menu {

--- a/grupo11/static/css/edicao_style.css
+++ b/grupo11/static/css/edicao_style.css
@@ -126,6 +126,28 @@ html {
     background-color: #3E668E;
 }
 
+.rodape {
+    background-color: #4D77A8;
+    color: white;
+    text-align: center;
+    padding: 20px;
+    margin-top: 48px;
+}
+
+.rodape-texto {
+    margin: 10px 0;
+}
+
+.rodape-link {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.rodape-link:hover {
+    color: #c0d8e8;
+}
+
 /* Resposividade */
 @media only screen and (max-width: 1300px) {
     .cabecalho-menu {

--- a/grupo11/static/css/login_style.css
+++ b/grupo11/static/css/login_style.css
@@ -128,6 +128,28 @@ html {
     font-size: 16px;
 }
 
+.rodape {
+    background-color: #4D77A8;
+    color: white;
+    text-align: center;
+    padding: 20px;
+    margin-top: 48px;
+}
+
+.rodape-texto {
+    margin: 10px 0;
+}
+
+.rodape-link {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.rodape-link:hover {
+    color: #c0d8e8;
+}
+
 /* Responsividade */
 @media only screen and (max-width: 768px) {
     .cabecalho-menu {

--- a/grupo11/static/css/sucesso_style.css
+++ b/grupo11/static/css/sucesso_style.css
@@ -112,6 +112,29 @@ body {
     height: auto;
 }
 
+.rodape {
+    background-color: #4D77A8;
+    color: white;
+    text-align: center;
+    padding: 20px;
+    margin-top: 48px;
+}
+
+.rodape-texto {
+    margin: 10px 0;
+}
+
+.rodape-link {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.rodape-link:hover {
+    color: #c0d8e8;
+}
+
+
 @media only screen and (max-width: 600px) {
 
     .cabecalho-menu {

--- a/grupo11/static/css/visualizacao_style.css
+++ b/grupo11/static/css/visualizacao_style.css
@@ -139,6 +139,29 @@ td button:hover {
     background-color: #3E668E;
 }
 
+.rodape {
+    background-color: #4D77A8;
+    color: white;
+    text-align: center;
+    padding: 20px;
+    margin-top: 48px;
+}
+
+.rodape-texto {
+    margin: 10px 0;
+}
+
+.rodape-link {
+    color: white;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.rodape-link:hover {
+    color: #c0d8e8;
+}
+
+
 /* Responsividade */
 @media only screen and (max-width: 1366px) {
 


### PR DESCRIPTION
This pull request introduces a consistent footer (`.rodape`) across multiple CSS files in the project. The footer includes styling for text, links, and hover effects, ensuring a uniform look and feel across different pages.

### Addition of a consistent footer:

* Added a `.rodape` class in the following files to define a footer with a blue background (`#4D77A8`), white text, centered alignment, and padding:
  - `grupo11/static/css/deletar_style.css`
  - `grupo11/static/css/edicao_style.css`
  - `grupo11/static/css/login_style.css`
  - `grupo11/static/css/sucesso_style.css`
  - `grupo11/static/css/visualizacao_style.css`

* Added `.rodape-texto` for margin adjustments and `.rodape-link` for link styling, including a hover effect that changes the link color to light blue (`#c0d8e8`) in all the above files.